### PR TITLE
#SymfonyConHackday2017 add Symfony 4 support because there is problem in other bundles which…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ language: php
 php:
     - '5.6'
     - '7.0'
+    - '7.1'
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,18 @@ php:
     - '7.0'
     - '7.1'
 
+matrix:
+    fast_finish: true
+    include:
+        - php: 7.1
+          env: DEPENDENCIES=beta
+
 cache:
     directories:
         - $HOME/.composer/cache
+
+before_install:
+    - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
 
 install:
     - php Tests/fix_composer_json.php

--- a/Profiler/MessageQueueCollector.php
+++ b/Profiler/MessageQueueCollector.php
@@ -82,4 +82,12 @@ class MessageQueueCollector extends DataCollector
     {
         return 'enqueue.message_queue';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = [];
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6",
-        "symfony/framework-bundle": "^2.8|^3",
+        "symfony/framework-bundle": "^2.8|^3|^4.0",
         "enqueue/enqueue": "^0.8@dev",
         "enqueue/null": "^0.8@dev",
         "enqueue/async-event-dispatcher": "^0.8@dev"
@@ -27,9 +27,9 @@
         "enqueue/gps": "^0.8@dev",
         "enqueue/test": "^0.8@dev",
         "doctrine/doctrine-bundle": "~1.2",
-        "symfony/monolog-bundle": "^2.8|^3",
-        "symfony/browser-kit": "^2.8|^3",
-        "symfony/expression-language": "^2.8|^3"
+        "symfony/monolog-bundle": "^2.8|^3|^4.0",
+        "symfony/browser-kit": "^2.8|^3|^4.0",
+        "symfony/expression-language": "^2.8|^3|^4.0"
     },
     "autoload": {
         "psr-4": { "Enqueue\\Bundle\\": "" },


### PR DESCRIPTION
Also, I wanted to update https://github.com/liip/LiipImagineBundle/tree/2.0 this bundle, and there was a compatibility problem with enqueue-bundle because Symfony 4 support didn't exist.