### PR TITLE
Added autoconfiguration for PsrProcessor::class interface

### DIFF
--- a/DependencyInjection/EnqueueExtension.php
+++ b/DependencyInjection/EnqueueExtension.php
@@ -11,6 +11,7 @@ use Enqueue\Null\Symfony\NullTransportFactory;
 use Enqueue\Symfony\DefaultTransportFactory;
 use Enqueue\Symfony\DriverFactoryInterface;
 use Enqueue\Symfony\TransportFactoryInterface;
+use Interop\Queue\PsrProcessor;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -71,6 +72,9 @@ class EnqueueExtension extends Extension implements PrependExtensionInterface
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+
+        $container->registerForAutoconfiguration(PsrProcessor::class)
+            ->addTag('enqueue.client.processor');
 
         foreach ($config['transport'] as $name => $transportConfig) {
             $this->factories[$name]->createConnectionFactory($container, $transportConfig);

--- a/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
@@ -644,7 +644,9 @@ class EnqueueExtensionTest extends TestCase
             'transport' => [],
         ]], $container);
 
-        self::assertTrue($container->hasDefinition(PsrProcessor::class));
+        $autoconfigured = $container->getAutoconfiguredInstanceof();
+
+        self::assertArrayHasKey(PsrProcessor::class, $autoconfigured);
     }
 
     /**

--- a/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/EnqueueExtensionTest.php
@@ -17,6 +17,7 @@ use Enqueue\Symfony\DefaultTransportFactory;
 use Enqueue\Symfony\MissingTransportFactory;
 use Enqueue\Symfony\TransportFactoryInterface;
 use Enqueue\Test\ClassExtensionTrait;
+use Interop\Queue\PsrProcessor;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -631,6 +632,19 @@ class EnqueueExtensionTest extends TestCase
                 'need_package' => true,
             ],
         ]], $container);
+    }
+
+    public function testShouldLoadProcessAutoconfigureChildDefinition()
+    {
+        $container = $this->getContainerBuilder(true);
+
+        $extension = new EnqueueExtension();
+        $extension->load([[
+            'client' => [],
+            'transport' => [],
+        ]], $container);
+
+        self::assertTrue($container->hasDefinition(PsrProcessor::class));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,52 +1,64 @@
 {
-    "name": "enqueue/enqueue-bundle",
+    "name": "enqueue\/enqueue-bundle",
     "type": "symfony-bundle",
     "description": "Message Queue Bundle",
-    "keywords": ["messaging", "queue", "amqp", "rabbitmq"],
-    "homepage": "https://enqueue.forma-pro.com/",
+    "keywords": [
+        "messaging",
+        "queue",
+        "amqp",
+        "rabbitmq"
+    ],
+    "homepage": "https:\/\/enqueue.forma-pro.com\/",
     "license": "MIT",
     "require": {
         "php": ">=5.6",
-        "symfony/framework-bundle": "^2.8|^3|^4",
-        "enqueue/enqueue": "^0.8@dev",
-        "enqueue/null": "^0.8@dev",
-        "enqueue/async-event-dispatcher": "^0.8@dev"
+        "symfony\/framework-bundle": "^2.8|^3|^4",
+        "enqueue\/enqueue": "^0.8@dev",
+        "enqueue\/null": "^0.8@dev",
+        "enqueue\/async-event-dispatcher": "^0.8@dev"
     },
     "support": {
         "email": "opensource@forma-pro.com",
-        "issues": "https://github.com/php-enqueue/enqueue-dev/issues",
-        "forum": "https://gitter.im/php-enqueue/Lobby",
-        "source": "https://github.com/php-enqueue/enqueue-dev",
-        "docs": "https://github.com/php-enqueue/enqueue-dev/blob/master/docs/index.md"
+        "issues": "https:\/\/github.com\/php-enqueue\/enqueue-dev\/issues",
+        "forum": "https:\/\/gitter.im\/php-enqueue\/Lobby",
+        "source": "https:\/\/github.com\/php-enqueue\/enqueue-dev",
+        "docs": "https:\/\/github.com\/php-enqueue\/enqueue-dev\/blob\/master\/docs\/index.md"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.5",
-        "enqueue/stomp": "^0.8@dev",
-        "enqueue/amqp-ext": "^0.8@dev",
-        "php-amqplib/php-amqplib": "^2.7@dev",
-        "enqueue/amqp-lib": "^0.8@dev",
-        "enqueue/amqp-bunny": "^0.8@dev",
-        "enqueue/job-queue": "^0.8@dev",
-        "enqueue/fs": "^0.8@dev",
-        "enqueue/redis": "^0.8@dev",
-        "enqueue/dbal": "^0.8@dev",
-        "enqueue/sqs": "^0.8@dev",
-        "enqueue/gps": "^0.8@dev",
-        "enqueue/test": "^0.8@dev",
-        "doctrine/doctrine-bundle": "~1.2",
-        "symfony/monolog-bundle": "^2.8|^3|^4",
-        "symfony/browser-kit": "^2.8|^3|^4",
-        "symfony/expression-language": "^2.8|^3|^4"
+        "phpunit\/phpunit": "~5.5",
+        "enqueue\/stomp": "^0.8@dev",
+        "enqueue\/amqp-ext": "^0.8@dev",
+        "php-amqplib\/php-amqplib": "^2.7@dev",
+        "enqueue\/amqp-lib": "^0.8@dev",
+        "enqueue\/amqp-bunny": "^0.8@dev",
+        "enqueue\/job-queue": "^0.8@dev",
+        "enqueue\/fs": "^0.8@dev",
+        "enqueue\/redis": "^0.8@dev",
+        "enqueue\/dbal": "^0.8@dev",
+        "enqueue\/sqs": "^0.8@dev",
+        "enqueue\/gps": "^0.8@dev",
+        "enqueue\/test": "^0.8@dev",
+        "doctrine\/doctrine-bundle": "~1.2",
+        "symfony\/monolog-bundle": "^2.8|^3|^4",
+        "symfony\/browser-kit": "^2.8|^3|^4",
+        "symfony\/expression-language": "^2.8|^3|^4"
     },
     "autoload": {
-        "psr-4": { "Enqueue\\Bundle\\": "" },
+        "psr-4": {
+            "Enqueue\\Bundle\\": ""
+        },
         "exclude-from-classmap": [
-            "/Tests/"
+            "\/Tests\/"
         ]
     },
     "extra": {
         "branch-alias": {
             "dev-master": "0.8.x-dev"
+        }
+    },
+    "config": {
+        "platform": {
+            "ext-amqp": "1.7"
         }
     }
 }


### PR DESCRIPTION
This will allow to Symfony users that have autowiring & autoconfigure enabled in their apps
not to be explicit about defining a Processor service, and setting up the tag. Symfony will
do it for the automatically now.