### PR TITLE
Fix TreeBuilder for Symfony 4.2

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,8 +24,8 @@ final class Configuration implements ConfigurationInterface
 
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $tb = new TreeBuilder();
-        $rootNode = $tb->root('enqueue');
+        $tb = new TreeBuilder('enqueue');
+        $rootNode = $tb->getNodeRoot();
 
         $rootNode
             ->requiresAtLeastOneElement()


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0.