### PR TITLE
Drop support for EOL PHP version, same for Symfony

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1', '8.2']
+        php: ['8.1', '8.2']
 
     name: PHP ${{ matrix.php }} tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /composer.lock
 /composer.phar
 /phpunit.xml
+/.phpunit.result.cache
 /vendor/
 /.idea/

--- a/Profiler/MessageQueueCollector.php
+++ b/Profiler/MessageQueueCollector.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class MessageQueueCollector extends AbstractMessageQueueCollector
 {
-    public function collect(Request $request, Response $response, Throwable $exception = null)
+    public function collect(Request $request, Response $response, Throwable $exception = null): void
     {
         $this->collectInternal($request, $response);
     }

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     "homepage": "https://enqueue.forma-pro.com/",
     "license": "MIT",
     "require": {
-        "php": "^7.4|^8.0",
-        "symfony/framework-bundle": "^5.4|^6.0",
+        "php": "^8.1",
+        "symfony/framework-bundle": "^5.4|^6.4",
         "queue-interop/amqp-interop": "^0.8.2",
         "queue-interop/queue-interop": "^0.8",
         "enqueue/enqueue": "^0.10",
@@ -21,6 +21,7 @@
         "docs": "https://github.com/php-enqueue/enqueue-dev/blob/master/docs/index.md"
     },
     "require-dev": {
+        "dms/phpunit-arraysubset-asserts": "^0.5.0",
         "phpunit/phpunit": "^9.5",
         "enqueue/stomp": "0.10.x-dev",
         "enqueue/amqp-ext": "0.10.x-dev",


### PR DESCRIPTION
see 
* https://symfony.com/releases
* https://www.php.net/supported-versions